### PR TITLE
fix: Remove disabled attribute buttons

### DIFF
--- a/src/components/attributeSelection/AttributeSelection.vue
+++ b/src/components/attributeSelection/AttributeSelection.vue
@@ -49,8 +49,7 @@
 @import "@/assets/styles/variables.scss";
 #button-wrapper {
   display: grid;
-  grid-template:
-    ". but but but ."
+  grid-template: ". but but but .";
 }
 .selections-grid {
   grid-area: but;

--- a/src/components/attributeSelection/AttributeSelection.vue
+++ b/src/components/attributeSelection/AttributeSelection.vue
@@ -49,7 +49,7 @@
 @import "@/assets/styles/variables.scss";
 #button-wrapper {
   display: grid;
-  grid-template: ". but but but .";
+  grid-template: ". but .";
 }
 .selections-grid {
   grid-area: but;

--- a/src/components/attributeSelection/AttributeSelection.vue
+++ b/src/components/attributeSelection/AttributeSelection.vue
@@ -2,25 +2,38 @@
   <div>
     <SelectionHeader :header="$t('$attributeSelectionTitle')" />
     <p class="error" v-if="showAttributeError">{{$t(attributeErrorMessage)}}</p>
-    <div class="selections-grid">
-      <SelectionButton name="$secchiDepth" :module="secchiDepthModule" :disabled="!sykeApiOnline" />
-      <SelectionButton name="$waterLevel" :module="waterLevelModule" :disabled="!fmiApiOnline" />
-      <SelectionButton name="$iceThickness" :module="iceThicknessModule" :disabled="!sykeApiOnline" />
-      <SelectionButton name="$surge" :module="surgeModule" :expandable="true" :disabled="!fmiApiOnline" />
-      <SelectionButton
-        name="$surfaceTemperature"
-        :module="surfaceTemperatureModule"
-        :expandable="true"
-        :disabled="!sykeApiOnline && !fmiApiOnline"
-      />
-      <SelectionButton
-        name="$waterQuality"
-        :module="waterQualityModule"
-        :expandable="true"
-        :disabled="!sykeApiOnline"
-      />
-      <SelectionButton name="$phytoplankton" :module="phytoplanktonModule" :disabled="true" />
-      <SelectionButton name="$benthicFauna" :module="benthicFaunaModule" :disabled="true" />
+    <div id="button-wrapper">
+      <div class="selections-grid">
+        <SelectionButton
+          name="$secchiDepth"
+          :module="secchiDepthModule"
+          :disabled="!sykeApiOnline"
+        />
+        <SelectionButton name="$waterLevel" :module="waterLevelModule" :disabled="!fmiApiOnline" />
+        <SelectionButton
+          name="$iceThickness"
+          :module="iceThicknessModule"
+          :disabled="!sykeApiOnline"
+        />
+        <SelectionButton
+          name="$surge"
+          :module="surgeModule"
+          :expandable="true"
+          :disabled="!fmiApiOnline"
+        />
+        <SelectionButton
+          name="$surfaceTemperature"
+          :module="surfaceTemperatureModule"
+          :expandable="true"
+          :disabled="!sykeApiOnline && !fmiApiOnline"
+        />
+        <SelectionButton
+          name="$waterQuality"
+          :module="waterQualityModule"
+          :expandable="true"
+          :disabled="!sykeApiOnline"
+        />
+      </div>
     </div>
     <div class="detail-box-container">
       <SurgeDetails v-if="surgeModule.isSelected" />
@@ -34,10 +47,15 @@
 
 <style lang="scss">
 @import "@/assets/styles/variables.scss";
-.selections-grid {
+#button-wrapper {
   display: grid;
-  grid-template-columns: 25% 25% 25% 25%;
-  grid-template-rows: auto;
+  grid-template:
+    ". but but but ."
+}
+.selections-grid {
+  grid-area: but;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
   grid-row-gap: 2rem;
 }
 .detail-box-container {

--- a/src/components/attributeSelection/OptionsSelection.vue
+++ b/src/components/attributeSelection/OptionsSelection.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="selection-box">
-    <fieldset class="selection-content">
+    <fieldset class="selection-content" :style="cssVars">
       <legend class="details-header">{{ header }}</legend>
       <label>
         <input
@@ -30,7 +30,7 @@
 .two-columns {
   display: grid;
   grid-template-columns: 1fr 1fr;
-  grid-template-rows: repeat(26, 1fr);
+  grid-template-rows: repeat(var(--length), 1fr);
   grid-auto-flow: column;
 }
 .option-label {

--- a/src/components/attributeSelection/optionsSelection.ts
+++ b/src/components/attributeSelection/optionsSelection.ts
@@ -31,4 +31,10 @@ export default class OptionsSelection extends Vue {
       this.module.deSelectAll();
     }
   }
+
+  get cssVars() {
+    return {
+      '--length': this.module.availableOptions.length / 2,
+    };
+  }
 }

--- a/src/components/attributeSelection/optionsSelection.ts
+++ b/src/components/attributeSelection/optionsSelection.ts
@@ -34,7 +34,7 @@ export default class OptionsSelection extends Vue {
 
   get cssVars() {
     return {
-      '--length': this.module.availableOptions.length / 2,
+      '--length': Math.ceil(this.module.availableOptions.length / 2),
     };
   }
 }


### PR DESCRIPTION
- Remove phytoplankton and benthic fauna attribute buttons as the data is not available yet
- Move attribute buttons closer to each other
- Make the column length in water quality options dynamic, so that adding more options to the database doesn't break the layout