### PR TITLE
Fix 'Resource not accessible by integration' pipeline error

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,8 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This should fix 'Resource not accessible by integration' error caused by [sticky-pull-request-comment](https://github.com/marocchino/sticky-pull-request-comment) tool in the Deploy preview job of the preview.yml pipeline (https://github.com/sykefi/marinedataportal/actions/runs/8543122575/job/23406210227) by following these instructions: https://github.com/marocchino/sticky-pull-request-comment?tab=readme-ov-file#error-resource-not-accessible-by-integration