### PR TITLE
fine tune permissions for actions

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -13,6 +13,9 @@ concurrency: preview-${{ github.ref }}
 jobs:
   deploy-preview:
     runs-on: ubuntu-20.04
+    permissions: 
+     pull-requests: write
+     contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Set the required permission manually, which at the very least doesn't seem to break the preview action any more than it already was