### PR TITLE
ungroup vue updates from the main update group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,9 @@ updates:
       interval: "monthly"
     groups:
       group-all:
+        exclude-patterns:
+        - "vue"
+        - "@vue/compiler*"
         update-types:
         - "minor"
         - "patch"


### PR DESCRIPTION
Newer vue versions break our map functionality, so split those updates away from the main updates to test each update individually