### PR TITLE
feat: perform OData queries by POST

### DIFF
--- a/src/apis/sykeApi.ts
+++ b/src/apis/sykeApi.ts
@@ -9,7 +9,10 @@ export default async function getVeslaData(resource: string, query: string) {
     while (res.nextLink) {
       const params = new URLSearchParams(res.nextLink.split('?')[1])
       const skipValue = params.get('$skip')
-      var newQuery = query + '&$skip=' + skipValue!
+      if (!skipValue) {
+        break
+      }
+      const newQuery = query + '&$skip=' + skipValue!
       res = await getJsonResponse(resource, newQuery)
       data.push(...res.value)
     }

--- a/src/apis/sykeApi.ts
+++ b/src/apis/sykeApi.ts
@@ -1,18 +1,15 @@
 import { useMainStateStore } from '@/stores/mainStateStore'
 
-export default async function getVeslaData(resource: string, parameters: string) {
+export default async function getVeslaData(resource: string, query: string) {
   const mainState = useMainStateStore()
   try {
-    let res = await getJsonResponse(resource, parameters)
+    let res = await getJsonResponse(resource, query)
     const data = res.value
 
-    
     while (res.nextLink) {
-      const params = new URLSearchParams(res.nextLink.split('?')[1]);
-      const skipValue = params.get('$skip');
-      var newParams = parameters=+'&$skip='+skipValue!;
-
-      res = await getJsonResponse(resource, newParams)
+      const params = new URLSearchParams(res.nextLink.split('?')[1])
+      const skipValue = params.get('$skip')
+      res = await getJsonResponse(resource, (query = +'&$skip=' + skipValue!))
       data.push(...res.value)
     }
     if (data.length && data[0] instanceof Object) {
@@ -41,15 +38,23 @@ interface ErrorResponse {
   }
 }
 
-async function getJsonResponse(resource: string, parameters: string): Promise<IODataResponse> {
-  const response = await fetch('https://rajapinnat.ymparisto.fi/api/meritietoportaali/api/'+resource+'/$query?api-version=1.0',{
-    method: 'post',
-    headers: {
-      'Accept': 'application/json',
-      'Content-Type': 'text/plain'
-    },
-    body: parameters
-  })
+async function getJsonResponse(
+  resource: string,
+  query: string
+): Promise<IODataResponse> {
+  const response = await fetch(
+    'https://rajapinnat.ymparisto.fi/api/meritietoportaali/api/' +
+      resource +
+      '/$query?api-version=1.0',
+    {
+      method: 'post',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'text/plain',
+      },
+      body: query,
+    }
+  )
   if (!response.ok) {
     let errorObj: ErrorResponse | undefined
     try {

--- a/src/apis/sykeApi.ts
+++ b/src/apis/sykeApi.ts
@@ -9,7 +9,8 @@ export default async function getVeslaData(resource: string, query: string) {
     while (res.nextLink) {
       const params = new URLSearchParams(res.nextLink.split('?')[1])
       const skipValue = params.get('$skip')
-      res = await getJsonResponse(resource, (query = +'&$skip=' + skipValue!))
+      var newQuery = query + '&$skip=' + skipValue!
+      res = await getJsonResponse(resource, newQuery)
       data.push(...res.value)
     }
     if (data.length && data[0] instanceof Object) {

--- a/src/queries/Vesla/getApiStatusQuery.ts
+++ b/src/queries/Vesla/getApiStatusQuery.ts
@@ -1,6 +1,6 @@
 import getVeslaData from '@/apis/sykeApi'
 
 export async function sykeApiIsOnline() {
-  const result = await getVeslaData('','')
+  const result = await getVeslaData('', '')
   return !!result
 }

--- a/src/queries/Vesla/getApiStatusQuery.ts
+++ b/src/queries/Vesla/getApiStatusQuery.ts
@@ -1,6 +1,6 @@
 import getVeslaData from '@/apis/sykeApi'
 
 export async function sykeApiIsOnline() {
-  const result = await getVeslaData('')
+  const result = await getVeslaData('','')
   return !!result
 }

--- a/src/queries/Vesla/getObservationsQuery.ts
+++ b/src/queries/Vesla/getObservationsQuery.ts
@@ -45,7 +45,7 @@ export async function getObservations(
     return []
   }
   const filter = await getFilter(params, obsCode)
-  let results = await getVeslaData(resource, query + filter)
+  let results = await getVeslaData(resource, query + '&' + filter)
   if (!results) {
     return []
   }

--- a/src/queries/Vesla/getObservationsQuery.ts
+++ b/src/queries/Vesla/getObservationsQuery.ts
@@ -16,10 +16,9 @@ const select = [
   'ParameterNameEng',
 ]
 
-const query =
-  'Observations?api-version=1.0&\
-$orderby=SiteId,Time&\
-$select=' + select.join(',')
+const resource = 'Observations'
+
+const query = '$orderby=SiteId,Time&$select=' + select.join(',')
 
 async function getFilter(params: CommonParameters, obsCode: string) {
   let filter =
@@ -46,7 +45,7 @@ export async function getObservations(
     return []
   }
   const filter = await getFilter(params, obsCode)
-  let results = await getVeslaData(query + filter)
+  let results = await getVeslaData(resource, query + filter)
   if (!results) {
     return []
   }
@@ -62,8 +61,7 @@ export async function getObservationSiteIds(
   obsCode: string
 ) {
   const filter = await getFilter(params, obsCode)
-  const q = 'Observations?api-version=1.0&$select=siteId' + filter
-  let data = await getVeslaData(q)
+  let data = await getVeslaData(resource, '$select=siteId' + filter)
   if (data) {
     data = data.map((d) => d.siteId)
   }

--- a/src/queries/Vesla/getVeslaSitesQuery.ts
+++ b/src/queries/Vesla/getVeslaSitesQuery.ts
@@ -2,9 +2,7 @@ import getVeslaData from '@/apis/sykeApi'
 import { Site, SiteTypes } from '../site'
 import { chunkArray, buildODataInFilterFromArray } from '@/helpers'
 
-const query =
-  'sites?api-version=1.0&\
-$select=SiteId,Name,Latitude,Longitude,Depth&'
+const query = '$select=SiteId,Name,Latitude,Longitude,Depth&'
 
 //use a generator function to get at most 200 sites at once
 //the staggered loading makes the UI more responsive when the user is loading hundreds of sites
@@ -15,7 +13,7 @@ export async function* getVeslaSites(ids: number[]) {
     if (chunk.find((i) => i > 0)) {
       const filter =
         '$filter=' + buildODataInFilterFromArray(chunk, 'SiteId', false)
-      const res = (await getVeslaData(query + filter)) as Array<{
+      const res = (await getVeslaData('Sites', query + filter)) as Array<{
         siteId: number
         name: string
         latitude: number

--- a/src/queries/Vesla/getWaterQualityOptionsQuery.ts
+++ b/src/queries/Vesla/getWaterQualityOptionsQuery.ts
@@ -1,8 +1,7 @@
 import getVeslaData from '@/apis/sykeApi'
 
 const query =
-  'determinationCombinations?api-version=1.0&\
-$select=DeterminationCombinationId,NameFi,NameSv,NameEn&\
+  '$select=DeterminationCombinationId,NameFi,NameSv,NameEn&\
 $orderby=DeterminationCombinationId'
 
 export interface IWaterQualityOption {
@@ -13,7 +12,7 @@ export interface IWaterQualityOption {
 }
 
 export async function getWaterQualityOptions() {
-  const res = await getVeslaData(query)
+  const res = await getVeslaData('DeterminationCombinations', query)
   const options: IWaterQualityOption[] = []
   if (res) {
     res.forEach((value) => {

--- a/src/queries/Vesla/getWaterQualityQuery.ts
+++ b/src/queries/Vesla/getWaterQualityQuery.ts
@@ -28,10 +28,9 @@ const select = [
   'flag',
 ]
 
-const query =
-  'results?api-version=1.0&\
-$orderby=DeterminationId,SiteId,Time&\
-$select=' + select.join(',')
+const resource = 'Results'
+
+const query = '$orderby=DeterminationId,SiteId,Time&$select=' + select.join(',')
 
 async function getFilter(
   params: CommonParameters,
@@ -39,7 +38,7 @@ async function getFilter(
   depth: IDepthSettings
 ) {
   let filter =
-    '&$filter= EnvironmentTypeId in (31,32,33)' +
+    '$filter= EnvironmentTypeId in (31,32,33)' +
     // results with W flag (W, WL, WG) are uncertain and not shown in the portal
     ` and (Flag eq null or not contains(Flag, 'W'))`
 
@@ -87,7 +86,7 @@ export async function getWaterQuality(
     return []
   }
   const filter = await getFilter(par, combinationIds, depth)
-  let results = await getVeslaData(query + filter)
+  let results = await getVeslaData(resource, query + '&' + filter)
   if (!results) {
     return []
   }
@@ -104,6 +103,5 @@ export async function getWaterQualitySiteIds(
   depth: IDepthSettings
 ) {
   const filter = await getFilter(par, combinationIds, depth)
-  const q = 'results/siteids?api-version=1.0&' + filter
-  return (await getVeslaData(q)) as number[]
+  return (await getVeslaData(resource, filter)) as number[]
 }

--- a/src/queries/getWaterQualityOptionsQuery.ts
+++ b/src/queries/getWaterQualityOptionsQuery.ts
@@ -1,9 +1,6 @@
 import getVeslaData from '@/apis/sykeApi'
 
-const query =
-  'MaaritysYhd?\
-$select=MaaritysYhd_Id,Nimi, NimiEng,&\
-$orderby=MaaritysYhd_Id&'
+const query = '$select=MaaritysYhd_Id,Nimi, NimiEng&$orderby=MaaritysYhd_Id'
 
 export interface IWaterQualityOption {
   id: number
@@ -12,7 +9,7 @@ export interface IWaterQualityOption {
 }
 
 export async function getWaterQualityOptions() {
-  const res = await getVeslaData(query)
+  const res = await getVeslaData('MaaritysYhd', query)
   const options: IWaterQualityOption[] = []
   if (res) {
     res.forEach((value) => {


### PR DESCRIPTION
This PR fixes an issue with the Vesla data search. Earlier, if the user picked a great number of sites (100+) the URL would become too long and the request would fail. Here we fix this by switching to POST queries instead of GET, meaning that the parameters go to the response body and therefore can be as long as needed

# Testing
1. https://sykefi.github.io/marinedataportal/pr-preview/pr-229/
2. Fetch secchi depth sites from 2022
3. Select all sites and fetch data - works
4. Repeat the steps for https://merihavainnot.ymparisto.fi/merihavainnot/ - breaks