### PR TITLE
optimize secchi/ice thickness site id fetching

### DIFF
--- a/src/queries/Vesla/getObservationsQuery.ts
+++ b/src/queries/Vesla/getObservationsQuery.ts
@@ -22,8 +22,7 @@ const query = '$orderby=SiteId,Time&$select=' + select.join(',')
 
 async function getFilter(params: CommonParameters, obsCode: string) {
   let filter =
-    '&$expand=Site($select=Latitude,Longitude,Depth)' +
-    '&$filter=Site/EnvironmentTypeId in (31,32,33)' +
+    'Site/EnvironmentTypeId in (31,32,33)' +
     ` and ParameterCode eq '${obsCode}'`
 
   filter += getTimeParametersForVeslaFilter(params)
@@ -44,8 +43,9 @@ export async function getObservations(
   if (params.veslaSites.length === 0) {
     return []
   }
-  const filter = await getFilter(params, obsCode)
-  let results = await getVeslaData(resource, query + '&' + filter)
+  let filter = await getFilter(params, obsCode)
+  filter += '&$expand=Site($select=Latitude,Longitude,Depth)'
+  let results = await getVeslaData(resource, query + '&$filter=' + filter)
   if (!results) {
     return []
   }
@@ -61,7 +61,7 @@ export async function getObservationSiteIds(
   obsCode: string
 ) {
   const filter = await getFilter(params, obsCode)
-  let data = await getVeslaData(resource, '$select=siteId' + filter)
+  let data = await getVeslaData(resource, '$apply=filter(' + filter + ')/groupby((siteId))&$orderby=siteId')
   if (data) {
     data = data.map((d) => d.siteId)
   }

--- a/src/queries/Vesla/getObservationsQuery.ts
+++ b/src/queries/Vesla/getObservationsQuery.ts
@@ -43,9 +43,14 @@ export async function getObservations(
   if (params.veslaSites.length === 0) {
     return []
   }
-  let filter = getFilter(params, obsCode)
-  filter += '&$expand=Site($select=Latitude,Longitude,Depth)'
-  let results = await getVeslaData(resource, query + '&$filter=' + filter)
+  const filter = getFilter(params, obsCode)
+  let results = await getVeslaData(
+    resource,
+    query +
+      '&$filter=' +
+      filter +
+      '&$expand=Site($select=Latitude,Longitude,Depth)'
+  )
   if (!results) {
     return []
   }

--- a/src/queries/Vesla/getObservationsQuery.ts
+++ b/src/queries/Vesla/getObservationsQuery.ts
@@ -20,7 +20,7 @@ const resource = 'Observations'
 
 const query = '$orderby=SiteId,Time&$select=' + select.join(',')
 
-async function getFilter(params: CommonParameters, obsCode: string) {
+function getFilter(params: CommonParameters, obsCode: string) {
   let filter =
     'Site/EnvironmentTypeId in (31,32,33)' +
     ` and ParameterCode eq '${obsCode}'`
@@ -43,7 +43,7 @@ export async function getObservations(
   if (params.veslaSites.length === 0) {
     return []
   }
-  let filter = await getFilter(params, obsCode)
+  let filter = getFilter(params, obsCode)
   filter += '&$expand=Site($select=Latitude,Longitude,Depth)'
   let results = await getVeslaData(resource, query + '&$filter=' + filter)
   if (!results) {
@@ -60,8 +60,11 @@ export async function getObservationSiteIds(
   params: CommonParameters,
   obsCode: string
 ) {
-  const filter = await getFilter(params, obsCode)
-  let data = await getVeslaData(resource, '$apply=filter(' + filter + ')/groupby((siteId))&$orderby=siteId')
+  const filter = getFilter(params, obsCode)
+  let data = await getVeslaData(
+    resource,
+    '$apply=filter(' + filter + ')/groupby((siteId))&$orderby=siteId'
+  )
   if (data) {
     data = data.map((d) => d.siteId)
   }


### PR DESCRIPTION
Greatly boost performance when fetching siteIds for secchi depth or ice thickness.

Earlier we had a simple $filter + $select query, but this caused a lot of unnecessary requests with duplicated site ids in responses.

See the performance difference from main:

1. Select secchi depth
2. Start the time range from 1979
3. Query the data

This branch completes the site loading (which could probably be implemented in this same call, but that's a later optimization) in about 6 seconds, while the main branch takes more than a minute